### PR TITLE
Fixed path to minilibx in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ifeq ($(GET_OS), Darwin)
 	LFLAGS		= -I./includes
 else
 	OS			= LINUX
-	FRAMEWORK       = -Lminilibx -L/usr/lib -I./lib/minilibx -lmlx -lz -lm -lX11 -lXext
+	FRAMEWORK       = -L./lib/minilibx -L/usr/lib -I./lib/minilibx -lmlx -lz -lm -lX11 -lXext
 	LFLAGS		= -I/usr/include -O3	
 endif
 


### PR DESCRIPTION
Fixed path bug while compiling project but it's not full solution of bug #7 

While running program there is a runtime error. The program throws a **map error** but on `macos` does not
```
❯ ./cub3D maps/game.cub
Error
Map Error
```